### PR TITLE
Minor fix router title

### DIFF
--- a/src/sidebar.js
+++ b/src/sidebar.js
@@ -308,8 +308,8 @@ let sidebar = [
             },
             {
                 title: '<code>router</code>',
-                page_title: 'The <code>router</code> object',
-                title_tag: 'The router object',
+                page_title: '<code>router</code>',
+                title_tag: 'router',
                 icon:'/assets/img/object.svg',
                 source: '/Workers/router.md',
                 path: '/Workers/router',


### PR DESCRIPTION
We have our router page title as `Therouterobject`, just have the router as single word, following the other function or object