### PR TITLE
chore: Improve build speed

### DIFF
--- a/build.js
+++ b/build.js
@@ -212,18 +212,6 @@ function generateDocsHTML(filePath, rootDir, page, isIndex = false) {
     const markdown = fs.readFileSync(filePath, 'utf-8');
     let html = '';
 
-    // recursively copy the assets directory and its contents to the dist directory
-    const assetsDir = path.join(rootDir, 'assets');
-    const distAssetsDir = path.join(rootDir, '..', 'dist', 'assets');
-    createDirectoryRecursively(distAssetsDir);
-    fs.copySync(assetsDir, distAssetsDir);
-
-    // recursively copy the playground directory and its contents to the dist directory
-    const playgroundDir = path.join(rootDir, 'playground');
-    const distPlaygroundDir = path.join(rootDir, '..', 'dist', 'playground');
-    createDirectoryRecursively(distPlaygroundDir);
-    fs.copySync(playgroundDir, distPlaygroundDir);
-
     // Parse markdown once and store it
     const { frontMatter , content } = parseFrontMatter(markdown);
     const parsedHTML = marked.parse(content);
@@ -464,6 +452,7 @@ function generateDocsHTML(filePath, rootDir, page, isIndex = false) {
     }
 
     // Show an error if any playground examples referred to do not exist
+    const playgroundDir = path.join(rootDir, 'playground');
     for (const exampleID of usedPlaygroundExamples) {
         if (!fs.pathExistsSync(path.join(playgroundDir, 'examples', `${exampleID}.html`))) {
             console.error(`Warning: ${filePath} links to non-existent playground example '${exampleID}'`);
@@ -532,6 +521,19 @@ async function generateDocumentation(rootDir) {
     } catch (error) {
         console.error(error);
     }
+
+    // recursively copy the assets directory and its contents to the dist directory
+    const assetsDir = path.join(rootDir, 'assets');
+    const distAssetsDir = path.join(rootDir, '..', 'dist', 'assets');
+    createDirectoryRecursively(distAssetsDir);
+    fs.copySync(assetsDir, distAssetsDir);
+
+    // recursively copy the playground directory and its contents to the dist directory
+    const playgroundDir = path.join(rootDir, 'playground');
+    const distPlaygroundDir = path.join(rootDir, '..', 'dist', 'playground');
+    createDirectoryRecursively(distPlaygroundDir);
+    fs.copySync(playgroundDir, distPlaygroundDir);
+
     findMdFiles(rootDir); // Process files based on sidebar
 }
 


### PR DESCRIPTION
I noticed while working on our docs, build time is kinda slow. Especially with our setup right now, we always do full rebuild (no hot reload yet)

Then I found that we are doing this copy assets and playgrounds dir from src to dist, inside the `generateDocsHTML`.

This function is called for every single markdown file, to build the actual docs pages, surely we don't need to keep copying the same assets and playground folder everytime.

moved it outside the function, and it's now much faster. developing docs should be a much better experience now

before (~5 seconds)
<img width="685" height="102" alt="Screenshot 2025-10-30 at 14 27 27" src="https://github.com/user-attachments/assets/626493ef-fe40-45e5-bd69-4250423d51fd" />

after (~1 second)
<img width="674" height="102" alt="image" src="https://github.com/user-attachments/assets/d86165b6-0e67-41fa-8b76-d4651a551b65" />

