### PR TITLE
hotfix: prevent router navigation on examples button

### DIFF
--- a/build.js
+++ b/build.js
@@ -49,11 +49,11 @@ marked.use({
                     html += `<a href="/playground/index.html?example=${exampleID}&autorun=1" class="code-button run-code-button" target="_blank"><span class="run"></span></a>`;
 
                 // "Copy"
-                html += '<a class="code-button copy-code-button"><span class="copy"></span></a>';
+                html += '<div class="code-button copy-code-button"><span class="copy"></span></div>';
 
                 // "Download"
                 if (exampleID)
-                    html += '<a class="code-button download-code-button"><span class="download"></span></a>';
+                    html += '<div class="code-button download-code-button"><span class="download"></span></div>';
             html += '</div>';
             html += `<pre><code ${lang ? `class="language-${encode(lang)}"` : '' }>`;
             html += escaped ? code : encode(code);

--- a/src/assets/js/context-menu.js
+++ b/src/assets/js/context-menu.js
@@ -22,6 +22,7 @@ jQuery(document).ready(function () {
         const blob = new Blob([$code], { type: 'text/plain' });
         const url = URL.createObjectURL(blob);
         const a = document.createElement('a');
+        a.className = 'skip-insta-load';
         a.href = url;
         a.download = $filename;
         document.body.appendChild(a);

--- a/src/assets/js/router.js
+++ b/src/assets/js/router.js
@@ -33,7 +33,7 @@ function isExternalLink(href) {
     }
 }
 
-$(document).on('click', 'a:not(.skip-insta-load)', function (e) {
+$(document).on('click', 'a:not(.skip-insta-load):not([target="_blank"])', function (e) {
     if (isCurrentPage($(this).attr('href')) || isExternalLink($(this).attr('href'))) {
         // default browser behavior
         return;


### PR DESCRIPTION
since router anchor tag is catching everything, these anchor tags are also unexpectedly caught

hotfixing this by omitting the ones that are target _blank, and adding the skip insta load