### PR TITLE
hotfix: Set state for router first navigation

### DIFF
--- a/src/assets/js/router.js
+++ b/src/assets/js/router.js
@@ -1,8 +1,13 @@
 jQuery(document).ready(function () {
     //History API
     if (window.history && window.history.pushState) {
+        // Initialize state for the first page
+        if (!window.history.state) {
+            window.history.replaceState({ reload: true }, document.title, window.location.href);
+        }
+
         $(window).on('popstate', function () {
-            if (window.history.state.reload) {
+            if (window.history.state && window.history.state.reload) {
                 window.location.href = window.location.href;
             }
         });


### PR DESCRIPTION
There's a minor issue where the back and forward button won't do anything if it's the first navigation.

The reason for this is there isn't yet an intial state for it, this PR should fix it.