### PR TITLE
Fix info vertical centering

### DIFF
--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -713,6 +713,10 @@ ol li::before {
 	height: 30px;
 }
 
+.info p {
+    margin: 5px 0;
+}
+
 .example-group {
 	border-radius: 5px;
 	display: flex;


### PR DESCRIPTION
Fixes #58 

before
<img width="780" height="316" alt="image" src="https://github.com/user-attachments/assets/ff212b96-c26f-4fd1-847d-1996fcd30a66" />

after
<img width="827" height="348" alt="image" src="https://github.com/user-attachments/assets/328d339d-b20b-49fc-aaf3-0bc9b686ab00" />
