### PR TITLE
Fix authenticateWithPuter example and content

### DIFF
--- a/src/UI/authenticateWithPuter.md
+++ b/src/UI/authenticateWithPuter.md
@@ -12,23 +12,30 @@ puter.ui.authenticateWithPuter()
 ```
 
 ## Parameters
+
 None.
 
 ## Return value
-A `Promise` that will resolve to `true`. If the user cancels the dialog, the promise will be rejected with an error.
+
+A `Promise` that resolves once the user is authenticated with their Puter account. If the user cancels the dialog, the promise will be rejected with an error.
 
 ## Examples
 
 ```html
 <html>
-<body>
+  <body>
     <script src="https://js.puter.com/v2/"></script>
     <script>
-        // Presents a dialog to the user to authenticate with their Puter account.
-        puter.ui.authenticateWithPuter().then((user)=>{
-            console.log(user)
+      // Presents a dialog to the user to authenticate with their Puter account.
+      puter.ui
+        .authenticateWithPuter()
+        .then(() => {
+          console.log("Authentication success!");
+        })
+        .catch((error) => {
+          console.error("Authentication failed: ", error);
         });
     </script>
-</body>
+  </body>
 </html>
 ```


### PR DESCRIPTION
Fixes #60 

- fix return value (we don't return anything for auth with puter)
- improve example