### PR TITLE
Add workers snippet to supported platforms

### DIFF
--- a/src/supported-platforms.md
+++ b/src/supported-platforms.md
@@ -111,3 +111,16 @@ Get started quickly with the [Node.js + Express template](https://github.com/Hey
 [Serverless Workers](/Workers/) let you run HTTP servers and backend APIs.
 
 Think of them as your serverless backend and API endpoints. Just like in other serverless platforms, you can use Puter.js in workers to access AI, cloud storage, key-value stores, and databases.
+
+```js
+// Simple GET endpoint
+router.get("/api/hello", async ({ request }) => {
+  return { message: "Hello, World!" };
+});
+
+// POST endpoint with JSON body
+router.post("/api/user", async ({ request }) => {
+  const body = await request.json();
+  return { processed: true };
+});
+```


### PR DESCRIPTION
<img width="844" height="495" alt="image" src="https://github.com/user-attachments/assets/8eb1adb4-f305-40f6-b27f-77042b4c7d74" />

it's always weird to me that we didn't show atleast a code example for workers in our supported platforms example, while other platform have some sort of example

adding a simple snippet here so people can instantly know what's going on